### PR TITLE
Add initial TOMO marketing site skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,5 @@ simulation of the Oxygen hosting platform. It therefore isn't compatible with a 
 deployed to Netlify.
 
 Instead, use the [Netlify CLI](https://docs.netlify.com/cli/get-started/) (e.g. `netlify serve`).
+## TOMO App
+See ./tomo for the TOMO marketing site implemented with Next.js.

--- a/tomo/README.md
+++ b/tomo/README.md
@@ -1,0 +1,12 @@
+# TOMO Website
+
+This folder contains a minimal Next.js 14 App Router setup for the TOMO marketing site.
+
+## Available scripts
+
+- `pnpm dev` – start development server
+- `pnpm build` – production build
+- `pnpm start` – run production build
+- `pnpm lint` – run ESLint
+
+These commands assume dependencies are installed via `pnpm install`.

--- a/tomo/app/about/page.tsx
+++ b/tomo/app/about/page.tsx
@@ -1,0 +1,3 @@
+export default function AboutPage() {
+  return <div>Brand story coming soon.</div>;
+}

--- a/tomo/app/accessibility/page.tsx
+++ b/tomo/app/accessibility/page.tsx
@@ -1,0 +1,3 @@
+export default function AccessibilityPage() {
+  return <div>Accessibility statement.</div>;
+}

--- a/tomo/app/api/revalidate/route.ts
+++ b/tomo/app/api/revalidate/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+import { revalidatePath } from 'next/cache';
+
+export async function GET(req: NextRequest) {
+  const secret = req.nextUrl.searchParams.get('secret');
+  if (secret !== process.env.REVALIDATE_SECRET) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  const path = req.nextUrl.searchParams.get('path') || '/';
+  revalidatePath(path);
+  return new Response('OK');
+}

--- a/tomo/app/layout.tsx
+++ b/tomo/app/layout.tsx
@@ -1,0 +1,3 @@
+import RootLayout from '../components/RootLayout';
+
+export default RootLayout;

--- a/tomo/app/menu/page.tsx
+++ b/tomo/app/menu/page.tsx
@@ -1,0 +1,3 @@
+export default function MenuPage() {
+  return <div>TODO: Sandwich grid coming soon.</div>;
+}

--- a/tomo/app/page.tsx
+++ b/tomo/app/page.tsx
@@ -1,0 +1,11 @@
+import HeadingXL from '../components/HeadingXL';
+import BtnPrimary from '../components/BtnPrimary';
+
+export default function Page() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center text-center space-y-8">
+      <HeadingXL>Freshly pressed. Maltese soul, Italian heart.</HeadingXL>
+      <BtnPrimary>Order on Wolt</BtnPrimary>
+    </main>
+  );
+}

--- a/tomo/components/BtnPrimary.tsx
+++ b/tomo/components/BtnPrimary.tsx
@@ -1,0 +1,10 @@
+import { ButtonHTMLAttributes } from 'react';
+
+export default function BtnPrimary(props: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      {...props}
+      className="bg-accent-basil text-neutral-white px-6 py-3 active:scale-95"
+    />
+  );
+}

--- a/tomo/components/CardFlavor.tsx
+++ b/tomo/components/CardFlavor.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+
+export default function CardFlavor({ children }: { children: ReactNode }) {
+  return (
+    <div className="aspect-[4/5] shadow-lg transition-transform hover:scale-105">
+      {children}
+    </div>
+  );
+}

--- a/tomo/components/HeadingXL.tsx
+++ b/tomo/components/HeadingXL.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+
+export default function HeadingXL({ children }: { children: ReactNode }) {
+  return (
+    <h1 className="text-5xl md:text-6xl font-domine italic leading-tight tracking-tight">
+      {children}
+    </h1>
+  );
+}

--- a/tomo/components/RootLayout.tsx
+++ b/tomo/components/RootLayout.tsx
@@ -1,0 +1,20 @@
+import './globals.css';
+import { ReactNode } from 'react';
+import { Domine, Inter } from 'next/font/google';
+import { Metadata } from 'next';
+
+const domine = Domine({ subsets: ['latin'], variable: '--font-domine', display: 'swap' });
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter', display: 'swap' });
+
+export const metadata: Metadata = {
+  title: 'TOMO',
+  description: 'Freshly pressed. Maltese soul, Italian heart.',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className={`${domine.variable} ${inter.variable}`}> 
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tomo/components/SectionSlab.tsx
+++ b/tomo/components/SectionSlab.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react';
+
+export default function SectionSlab({ children }: { children: ReactNode }) {
+  return <section className="bg-core-red text-white py-16">{children}</section>;
+}

--- a/tomo/next-env.d.ts
+++ b/tomo/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/messages/typescript-nextjs-tsconfig

--- a/tomo/next.config.js
+++ b/tomo/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: { appDir: true },
+};
+export default nextConfig;

--- a/tomo/package.json
+++ b/tomo/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "tomo",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@sanity/client": "^5.13.3",
+    "@sanity/image-url": "^1.0.2",
+    "keen-slider": "^6.8.3",
+    "mapbox-gl": "^2.15.0",
+    "@mapbox/mapbox-gl-geocoder": "^5.1.2",
+    "framer-motion": "^11.1.4"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.2.2"
+  }
+}

--- a/tomo/postcss.config.js
+++ b/tomo/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tomo/styles/globals.css
+++ b/tomo/styles/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body { background-color: theme('colors.neutral.cream'); }
+
+@media (min-width: 768px) {
+  ::-webkit-scrollbar {
+    display: none;
+  }
+}

--- a/tomo/styles/tokens.json
+++ b/tomo/styles/tokens.json
@@ -1,0 +1,13 @@
+{
+  "colors": {
+    "core-red": "#D7262E",
+    "accent-basil": "#316B3C",
+    "neutral-cream": "#FFF8EF",
+    "neutral-espresso": "#1B0B0B",
+    "neutral-white": "#FFFFFF"
+  },
+  "font": {
+    "domine": "Domine, serif",
+    "inter": "Inter, sans-serif"
+  }
+}

--- a/tomo/tailwind.config.js
+++ b/tomo/tailwind.config.js
@@ -1,0 +1,30 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+const plugins = [
+  require('@tailwindcss/typography'),
+  require('@tailwindcss/aspect-ratio'),
+  require('@tailwindcss/container-queries'),
+];
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        core: { red: '#D7262E' },
+        accent: { basil: '#316B3C' },
+        neutral: {
+          cream: '#FFF8EF',
+          espresso: '#1B0B0B',
+          white: '#FFFFFF',
+        },
+      },
+      fontFamily: {
+        domine: ['Domine', 'serif'],
+        inter: ['Inter', 'sans-serif'],
+      },
+    },
+  },
+  plugins,
+};

--- a/tomo/tsconfig.json
+++ b/tomo/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["@types/node"],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "./**/*.ts", "./**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add `tomo` folder containing a minimal Next.js 14 App Router project
- configure Tailwind with TOMO tokens and baseline global styles
- implement basic components and placeholder pages
- link to new site in root README

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm --prefix tomo run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686719c1dfc88326a08c7ead424418c1